### PR TITLE
Fully transparent status & navigation bar on Android API Level v29+

### DIFF
--- a/app/src/main/res/values-v29/themes.xml
+++ b/app/src/main/res/values-v29/themes.xml
@@ -29,4 +29,13 @@
         <item name="android:windowLightStatusBar">false</item>
         <item name="materialAlertDialogTheme">@style/AlertDialogStyle</item>
     </style>
+
+    <style name="NonFullScreenTheme" parent="AppTheme">
+        <item name="android:statusBarColor">@color/colorPrimary</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowShowWallpaper">false</item>
+        <item name="android:windowBackground">@color/colorPrimary</item>
+        <item name="android:windowLightStatusBar">@bool/windowLightStatusBar</item>
+        <item name="android:enforceNavigationBarContrast">true</item>
+    </style>
 </resources>

--- a/app/src/main/res/values-v29/themes.xml
+++ b/app/src/main/res/values-v29/themes.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
     <style name="AppTheme" parent="Theme.MaterialComponents.DayNight">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
@@ -20,18 +21,12 @@
         <item name="android:textColor">@color/colorOnPrimary</item>
         <item name="android:textColorSecondary">@color/colorOnPrimary</item>
 
+        <item name="android:enforceNavigationBarContrast">false</item>
         <item name="android:windowShowWallpaper">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
-        <item name="android:windowLightStatusBar">@bool/windowLightStatusBar</item>
+        <item name="android:windowLightStatusBar">false</item>
         <item name="materialAlertDialogTheme">@style/AlertDialogStyle</item>
-    </style>
-
-    <style name="NonFullScreenTheme" parent="AppTheme">
-        <item name="android:statusBarColor">@color/colorPrimary</item>
-        <item name="android:navigationBarColor">@color/colorPrimary</item>
-        <item name="android:windowShowWallpaper">false</item>
-        <item name="android:windowBackground">@color/colorPrimary</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -22,8 +22,8 @@
 
         <item name="android:windowShowWallpaper">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">@color/primary_translucent</item>
+        <item name="android:navigationBarColor">@color/primary_translucent</item>
         <item name="android:windowLightStatusBar">@bool/windowLightStatusBar</item>
         <item name="materialAlertDialogTheme">@style/AlertDialogStyle</item>
     </style>


### PR DESCRIPTION
Issue: #33, #31
As mentioned in the commit messages, I couldn't find a non-programmatic way to change behaviour pre-v29 API, due to android:enforceNavigationBarContrast & android:enforceStatusBarContrast XML tags only existing on v29+. I also believe this will not present an issue, since the default behaviour is preserved.